### PR TITLE
Delete aws_credentials_smartstudy.csv

### DIFF
--- a/aws_credentials_smartstudy.csv
+++ b/aws_credentials_smartstudy.csv
@@ -1,2 +1,0 @@
-User Name,Access Key Id,Secret Access Key
-"smartstudy",AKIAJGKSUB57R4GHZILA,nv+QN66wYgb2TcrDQc0CtxV7KaobxPSdXds9dvvZ


### PR DESCRIPTION
Publicly exposing AWS Access Keys is a security risk and violation of the AWS Customer Agreement. Please remove and follow instructions at https://help.github.com/articles/remove-sensitive-data/. (The access key is also no longer active.)
